### PR TITLE
POI timing

### DIFF
--- a/Assets/Scenes/CoreSystems.unity
+++ b/Assets/Scenes/CoreSystems.unity
@@ -1674,7 +1674,7 @@ TextMesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 720700953}
-  m_Text: 'Year: 0'
+  m_Text: 9,240,000,000 years
   m_OffsetZ: 0
   m_CharacterSize: 0.003
   m_LineSpacing: 1

--- a/Assets/Scenes/Views/GalaxyView.unity
+++ b/Assets/Scenes/Views/GalaxyView.unity
@@ -959,6 +959,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 414c0273c3a8b104a9cef1e727d36ec1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  spiralContainer: {fileID: 0}
+  spiralPath: {fileID: 0}
+  bezPath: {fileID: 0}
+  pathResolution: 24
 --- !u!4 &1379719062 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 419008, guid: 73b8f8966f5a07d41b81a2b392c754c9,
@@ -1241,6 +1245,34 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 490906, guid: 4f26b92d8d5712d4db1381c636fc91a5,
     type: 2}
   m_PrefabInternal: {fileID: 1813358447}
+--- !u!1 &1763360469
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1763360470}
+  m_Layer: 0
+  m_Name: POITarget
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1763360470
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1763360469}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1899807949}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1813358447
 Prefab:
   m_ObjectHideFlags: 0
@@ -1345,6 +1377,7 @@ Transform:
   - {fileID: 1379719062}
   - {fileID: 1752822994}
   - {fileID: 391538166}
+  - {fileID: 1763360470}
   m_Father: {fileID: 1296047784}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/ChronozoomLoader.cs
+++ b/Assets/Scripts/ChronozoomLoader.cs
@@ -19,7 +19,7 @@ namespace GalaxyExplorer
         private bool onlyPictures = true;
 
         //Change this to limit the number of exhibits that are instantiated. Set limit to around 100 to prevent text overload
-        private int maxExhibits = 100;
+        //private int maxExhibits = 100;
 
         //void Awake()
         //{

--- a/Assets/Scripts/DynamicPOI.cs
+++ b/Assets/Scripts/DynamicPOI.cs
@@ -15,6 +15,8 @@ namespace GalaxyExplorer
 
         private PlotPatternSpiralPath pattern;
 
+        private float wait = 0;
+
         public void PlotItems(string context)
         {
             if (context == "GalaxyView")
@@ -43,7 +45,6 @@ namespace GalaxyExplorer
                     timekeeper.updateActions.Add(year =>
                     {
                         float timediff = year - now;
-                        Debug.Log(timediff);
                         List<Exhibit> toPlot = exList.FindAll(ex => ex.time <= timediff);
 
                         if (toPlot.Count > 0)
@@ -94,7 +95,14 @@ namespace GalaxyExplorer
 
         void Update()
         {
-            if (initPlot.Count > 0) initPlot.Dequeue()(); // plot once per update
+            wait += Time.deltaTime;
+            if (wait >= 1)
+            {
+                wait %= 1;
+                if (initPlot.Count > 0) initPlot.Dequeue()();
+                // plot once per second, so items have some distance apart - sacrifices exact timing
+            }
+            
             if (points.Count > 0) // move the points along
             {
                 for (int i = 0; i < points.Count; i++)

--- a/Assets/Scripts/DynamicPOI.cs
+++ b/Assets/Scripts/DynamicPOI.cs
@@ -15,6 +15,8 @@ namespace GalaxyExplorer
 
         private PlotPatternSpiralPath pattern;
 
+        private Transform galaxy;
+
         private float wait = 0;
 
         public void PlotItems(string context)
@@ -22,7 +24,7 @@ namespace GalaxyExplorer
             if (context == "GalaxyView")
             {
                 Transform hero = transform.Find(context + "Content/SceneLoadHider/HeroView");
-                Transform parent = hero.Find("POIRotation");
+                galaxy = hero.Find("POIRotation");
 
                 // get the elements to plot
                 ChronozoomLoader loader = new ChronozoomLoader();
@@ -57,7 +59,7 @@ namespace GalaxyExplorer
                                     ex.id,
                                     ex.title,
                                     null,
-                                    pattern.GetSpiralNode(i -1),
+                                    pattern.GetSpiralNode(i - 1),
                                     pattern.GetSpiralNode(i)));
                             });
                         }
@@ -66,27 +68,44 @@ namespace GalaxyExplorer
             }
         }
 
-        POITracker Jump (POITracker tracker)
+        POITracker Jump(POITracker tracker)
         {
             tracker.jump = false;
             tracker.targetIndex = 0;
 
-            if (tracker.gameObject.transform.IsChildOf(pattern.spiralContainer.transform))
+            if (tracker.gameObject.transform.IsChildOf(pattern.spiralPath.transform))
             {
                 // was on spiral, move to path
                 tracker.gameObject.transform.SetParent(pattern.bezPath.transform);
-                
+
                 tracker.target = pattern.GetPathNode(0);
                 tracker.next = (int i) => pattern.GetPathNode(i);
+            }
+            else if (tracker.gameObject.transform.IsChildOf(pattern.bezPath.transform))
+            {
+                // was on path, move to galaxy
+                tracker.gameObject.transform.SetParent(galaxy);
+
+                tracker.target = galaxy.Find("POITarget");
+                tracker.next = (int i) => null;
+            }
+            else if (tracker.gameObject.transform.IsChildOf(galaxy))
+            {
+                // was on galaxy, REMOVE FROM LIST AND DELETE OBJECT
+                Destroy(tracker.gameObject);
+                return null;
             }
 
             return tracker;
         }
 
         // move the POI towards the next node
-        POITracker Move (POITracker tracker)
+        POITracker Move(POITracker tracker)
         {
             float step = (poiSpeed * Time.deltaTime) * GalaticController.instance.speedMultiplier;
+            if (tracker.gameObject.transform.IsChildOf(galaxy)) step *= .1f; // move slower inside galaxy (it quickly reaches the centre)
+            if (tracker.gameObject.transform.IsChildOf(pattern.bezPath.transform)) step *= 1.5f; // appears to move slower on the path, speed up
+
             tracker.gameObject.transform.position =
                 Vector3.MoveTowards(tracker.gameObject.transform.position, tracker.target.position, step);
 
@@ -96,37 +115,45 @@ namespace GalaxyExplorer
         void Update()
         {
             wait += Time.deltaTime;
-            if (wait >= 1)
+            if (wait >= .5f)
             {
-                wait %= 1;
+                wait %= .5f;
                 if (initPlot.Count > 0) initPlot.Dequeue()();
-                // plot once per second, so items have some distance apart - sacrifices exact timing
+                // plot once per .5 sec, so items have some distance apart - sacrifices exact timing
             }
-            
+
             if (points.Count > 0) // move the points along
             {
                 for (int i = 0; i < points.Count; i++)
                 {
-                    if (points[i].jump) points[i] = Jump(points[i]);
-                    Vector3 oldPos = points[i].gameObject.transform.position;
-
-                    points[i] = Move(points[i]);
-
-                    if (oldPos == points[i].gameObject.transform.position)
+                    if (points[i] != null)
                     {
-                        // poi has reached target, switch to next node and MOVE AGAIN HERE
-                        Transform target = points[i].next(++points[i].targetIndex);
-                        if (target == null) // no more nodes, jump to next rail
+                        if (points[i].jump) points[i] = Jump(points[i]);
+                        GameObject obj = points[i].gameObject;
+                        if (obj != null)
                         {
-                            points[i] = Jump(points[i]);
-                        }
-                        else
-                        {
-                            points[i].gameObject.transform.SetParent(points[i].target);
-                            points[i].target = target;
-                        }
+                            Vector3 oldPos = obj.transform.position;
 
-                        points[i] = Move(points[i]);
+                            points[i] = Move(points[i]);
+
+                            if (oldPos == obj.transform.position)
+                            {
+                                // poi has reached target, switch to next node and MOVE AGAIN HERE
+                                Transform target = points[i].next(++points[i].targetIndex);
+                                if (target == null) // no more nodes, jump to next rail
+                                {
+                                    points[i] = Jump(points[i]);
+                                }
+                                else
+                                {
+                                    obj.transform.SetParent(points[i].target);
+                                    points[i].target = target;
+                                }
+
+                                // point item can be removed after jump, gameobject being null is the indicator
+                                if (points[i] != null) points[i] = Move(points[i]);
+                            }
+                        }
                     }
                 }
             }
@@ -147,7 +174,8 @@ namespace GalaxyExplorer
             poi.transform.Find("ScaleWithDistance target/POI").gameObject.GetComponent<PointOfInterest>().TransitionScene = transitionScene;
             poi.transform.Find("ScaleWithDistance target/POI/ScaleWithDistance target/FaceCamera/Card").gameObject.GetComponent<TextMesh>().text = cardText;
 
-            points.Add(new POITracker() {
+            points.Add(new POITracker()
+            {
                 jump = targetNode == null ? true : false, // target == null if at last spiral node
                 targetIndex = index + 1,
                 target = targetNode,

--- a/Assets/Scripts/PlotPatternSpiralPath.cs
+++ b/Assets/Scripts/PlotPatternSpiralPath.cs
@@ -7,7 +7,10 @@ namespace GalaxyExplorer
     public class PlotPatternSpiralPath : MonoBehaviour
     {
         public GameObject spiralContainer;
+        public GameObject spiralPath;
         public GameObject bezPath;
+
+        public float pathResolution = 24f;
 
         private PlotPatternGalaxy spiralPattern = new PlotPatternGalaxy();
 
@@ -15,44 +18,46 @@ namespace GalaxyExplorer
         {
             spiralContainer = new GameObject("SpiralContainer");
             spiralContainer.transform.SetParent(transform);
-            spiralContainer.transform.localPosition = new Vector3(4, 1.75f, -.35f);
 
-            spiralContainer.transform.rotation = Quaternion.Euler(new Vector3(-117, 200, 125));
+            spiralPath = new GameObject("Spiral");
+            spiralPath.transform.SetParent(spiralContainer.transform);
+            spiralPath.transform.localPosition = new Vector3(-1.9f, 1.7f, 4.2f);
+            spiralPath.transform.rotation = Quaternion.Euler(new Vector3(-38, 35, -70));
 
             for (int i = 0; i < itemCount; i++)
             {
                 //GameObject sphere = new GameObject(string.Format("Node {0}", i));
                 GameObject sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-                sphere.transform.SetParent(spiralContainer.transform);
+                sphere.transform.SetParent(spiralPath.transform);
                 sphere.transform.localScale = new Vector3(.01f, .01f, .01f);
                 sphere.transform.localPosition = spiralPattern.GetPoint();
             }
 
             bezPath = new GameObject("BezierPath");
             bezPath.transform.SetParent(spiralContainer.transform);
-            bezPath.transform.localPosition = new Vector3(0, 0, 0);
+            //bezPath.transform.localPosition = new Vector3(0, 0, 0);
 
             BezierCurve curve = bezPath.AddComponent<BezierCurve>();
             curve.points = new Vector3[]
             {
-                new Vector3(.4f, -.165f, .25f),
-                new Vector3(.4f, -.7f, -.65f),
-                new Vector3(1.2f, -1.23f, -1.5f)
+                new Vector3(-1.5738f, 1.358f, 4.3781f),
+                new Vector3(-1.395f, .98f, 3.35f),
+                new Vector3(-.783f, .536f, 2.676f)
             };
 
-            for (int i = 0; i < 12; i++)
+            for (int i = 0; i < pathResolution; i++)
             {
                 GameObject sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
                 sphere.transform.SetParent(bezPath.transform);
                 sphere.transform.localScale = new Vector3(.01f, .01f, .01f);
-                sphere.transform.position = curve.GetPoint(i / 12f); // 12 just used for demo
+                sphere.transform.position = curve.GetPoint(i / pathResolution);
             }
         }
 
         public Transform GetSpiralNode(int index)
         {
-            if (index < spiralContainer.transform.childCount)
-                return spiralContainer.transform.GetChild(index);
+            if (index < spiralPath.transform.childCount)
+                return spiralPath.transform.GetChild(index);
             else return null;
         }
 

--- a/Assets/Scripts/PlotPatternSpiralPath.cs
+++ b/Assets/Scripts/PlotPatternSpiralPath.cs
@@ -29,7 +29,7 @@ namespace GalaxyExplorer
                 //GameObject sphere = new GameObject(string.Format("Node {0}", i));
                 GameObject sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
                 sphere.transform.SetParent(spiralPath.transform);
-                sphere.transform.localScale = new Vector3(.01f, .01f, .01f);
+                sphere.transform.localScale = new Vector3(.005f, .005f, .005f);
                 sphere.transform.localPosition = spiralPattern.GetPoint();
             }
 
@@ -48,8 +48,9 @@ namespace GalaxyExplorer
             for (int i = 0; i < pathResolution; i++)
             {
                 GameObject sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+                //GameObject sphere = new GameObject(string.Format("Node {0}", i));
                 sphere.transform.SetParent(bezPath.transform);
-                sphere.transform.localScale = new Vector3(.01f, .01f, .01f);
+                sphere.transform.localScale = new Vector3(.005f, .005f, .005f);
                 sphere.transform.position = curve.GetPoint(i / pathResolution);
             }
         }

--- a/Assets/Scripts/Timekeeper.cs
+++ b/Assets/Scripts/Timekeeper.cs
@@ -19,7 +19,7 @@ namespace GalaxyExplorer
             {
                 { TimeMode.Galaxy, new Dictionary<string, float>() {
                     { "rate", .000000355f }, // one year in game time seconds
-                    { "year", 0f }
+                    { "year", 9240000000f } // start at galaxy formation
                 } }
             };
 
@@ -52,7 +52,7 @@ namespace GalaxyExplorer
             if (this.mode != mode)
             {
                 if (this.mode != TimeMode.Stop)
-                    data[this.mode]["year"] = 0f; // clear the year counter
+                    data[this.mode]["year"] = 9240000000f; // clear the year counter
                 this.mode = mode;
             }
         }

--- a/Assets/Scripts/Timepiece.cs
+++ b/Assets/Scripts/Timepiece.cs
@@ -14,7 +14,7 @@ namespace GalaxyExplorer
             GameObject.Find("/ViewLoader").GetComponent<Timekeeper>()
                 .updateActions.Add(year =>
                 {
-                    tooltip.text = string.Format("Year: {0}",
+                    tooltip.text = string.Format("{0} years",
                         year.ToString("N0", CultureInfo.InvariantCulture));
                 });
         }


### PR DESCRIPTION
Display POI's at the time that they occur.

This PR also contains the following:
- start the timekeeper at 9,240,000,000 years, which is when the first event occurs
- implemented POI rail to the galaxy, allowing it to rotate in the galaxy
- implement a different speed for the various rails to be more consistency
- increase resolution points on the bezier path
- remove the POI when it reaches the galactic centre, reducing the number of elements on the field for performance
- allow one POI to be plotted every half second so there's room to hover over them individually